### PR TITLE
Rebuild to include missing runtime dependency momentchi2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:


### PR DESCRIPTION
This PR bumps the build number to trigger a rebuild after fixing a missing
runtime dependency.

Context:
- `momentchi2` is listed in `install_requires` upstream
- it was missing from `requirements: run:` in the conda-forge recipe
- tests previously installed it via pip, masking the issue

The dependency is now declared properly and the rebuild ensures users receive
the fix.
